### PR TITLE
refactor: standardize database service method naming and remove legacy code

### DIFF
--- a/mcp/src/tools/create-handler.ts
+++ b/mcp/src/tools/create-handler.ts
@@ -116,10 +116,10 @@ export async function handleCreate(
     }
   }
 
-  // Store task in database
+  // Store object in database
   let entityId: number;
   try {
-    entityId = await sharedDbService.createTask(taskData, clientId);
+    entityId = await sharedDbService.createObject(taskData, clientId);
   } catch (error) {
     console.error(`Error creating ${config.typeName.toLowerCase()}:`, error);
     return {
@@ -142,10 +142,10 @@ export async function handleCreate(
 
   if (projectId) {
     try {
-      const parentTask = await sharedDbService.getTask(projectId);
-      projectInfo = parentTask ? `${parentTask.Title || 'Untitled'}` : 'Unknown';
+      const parentObject = await sharedDbService.getObject(projectId);
+      projectInfo = parentObject ? `${parentObject.Title || 'Untitled'}` : 'Unknown';
     } catch (error) {
-      console.error('Error loading parent/project task:', error);
+      console.error('Error loading parent/project object:', error);
       projectInfo = 'Unknown';
     }
   }

--- a/mcp/src/tools/epic-tools.ts
+++ b/mcp/src/tools/epic-tools.ts
@@ -83,7 +83,7 @@ export class EpicTools {
         loadSchema: this.loadDynamicSchemaProperties,
         validateParent: async (parentId: number, dbService: DatabaseService) => {
           // Validate that parent is a project (template_id=2)
-          const parentProject = await dbService.getTask(parentId);
+          const parentProject = await dbService.getObject(parentId);
           if (!parentProject || parentProject.template_id !== 2) {
             throw new Error("Error: Epics must have a project as parent (template_id=2).");
           }
@@ -108,7 +108,7 @@ export class EpicTools {
         validateTemplateId: true,
         validateParent: async (parentId: number, dbService: DatabaseService) => {
           // Validate that parent is a project (template_id=2)
-          const parentProject = await dbService.getTask(parentId);
+          const parentProject = await dbService.getObject(parentId);
           if (!parentProject || parentProject.template_id !== 2) {
             throw new Error("Error: Epics must have a project as parent (template_id=2).");
           }

--- a/mcp/src/tools/object-tools.ts
+++ b/mcp/src/tools/object-tools.ts
@@ -95,7 +95,7 @@ export class ObjectTools {
     }
 
     // Get object from database
-    const object = await this.sharedDbService.getTask(objectId);
+    const object = await this.sharedDbService.getObject(objectId);
     if (!object) {
       return {
         content: [
@@ -112,7 +112,7 @@ export class ObjectTools {
     let parentType = null;
     if (object.parent_id) {
       try {
-        const parentObject = await this.sharedDbService.getTask(object.parent_id);
+        const parentObject = await this.sharedDbService.getObject(object.parent_id);
         if (parentObject) {
           parentName = parentObject.Title || 'Untitled';
           parentType = parentObject.template_id === 1 ? 'task' :
@@ -178,7 +178,7 @@ export class ObjectTools {
     }
 
     // Check if object exists
-    const existingObject = await this.sharedDbService.getTask(objectId);
+    const existingObject = await this.sharedDbService.getObject(objectId);
     if (!existingObject) {
       return {
         content: [
@@ -192,7 +192,7 @@ export class ObjectTools {
 
     // Delete object from database
     try {
-      const deleted = await this.sharedDbService.deleteTask(objectId);
+      const deleted = await this.sharedDbService.deleteObject(objectId);
       if (deleted) {
         const typeDisplay = existingObject.template_id === 1 ? 'Task' :
                             existingObject.template_id === 2 ? 'Project' :
@@ -253,8 +253,8 @@ export class ObjectTools {
     const stage = toolArgs?.stage as TaskStage | undefined;
 
     try {
-      const objects = await this.sharedDbService.listTasks(stage, parentId, templateId);
-      
+      const objects = await this.sharedDbService.listObjects(stage, parentId, templateId);
+
       const formattedObjects = objects.map(object => {
         const typeDisplay = object.template_id === 1 ? 'Task' :
                             object.template_id === 2 ? 'Project' :

--- a/mcp/src/tools/project-tools.ts
+++ b/mcp/src/tools/project-tools.ts
@@ -152,7 +152,7 @@ export class ProjectTools {
 
     // If project_id is provided (not null), verify the project exists
     if (projectId !== null) {
-      const existingProject = await this.sharedDbService.getTask(projectId);
+      const existingProject = await this.sharedDbService.getObject(projectId);
       if (!existingProject || existingProject.template_id !== 2) {
         return {
           content: [

--- a/mcp/src/tools/task-tools.ts
+++ b/mcp/src/tools/task-tools.ts
@@ -102,7 +102,7 @@ export class TaskTools {
           // Check if task is completed based on checkboxes in Items section
           if (updatedTask.Items && this.isTaskCompleted(updatedTask.Items)) {
             try {
-              await dbService.updateTask(taskId, { stage: 'review', template_id: 1 }, clientId);
+              await dbService.updateObject(taskId, { stage: 'review', template_id: 1 }, clientId);
               updatedTask.stage = 'review';
               return updatedTask;
             } catch (error) {

--- a/mcp/src/tools/update-handler.ts
+++ b/mcp/src/tools/update-handler.ts
@@ -42,7 +42,7 @@ export async function handleUpdate(
   }
 
   // Check if entity exists
-  const existingEntity = await sharedDbService.getTask(entityId);
+  const existingEntity = await sharedDbService.getObject(entityId);
   if (!existingEntity) {
     return {
       content: [
@@ -124,7 +124,7 @@ export async function handleUpdate(
 
   // Update entity in database
   try {
-    const updateResult = await sharedDbService.updateTask(entityId, updateData, clientId);
+    const updateResult = await sharedDbService.updateObject(entityId, updateData, clientId);
     if (!updateResult) {
       return {
         content: [
@@ -148,7 +148,7 @@ export async function handleUpdate(
   }
 
   // Fetch updated entity
-  const fetchedEntity = await sharedDbService.getTask(entityId);
+  const fetchedEntity = await sharedDbService.getObject(entityId);
   if (!fetchedEntity) {
     return {
       content: [


### PR DESCRIPTION
- Rename TaskData interface to ObjectData with deprecated type alias
- Rename database methods: createTask → createObject, updateTask → updateObject, getTask → getObject, deleteTask → deleteObject, listTasks → listObjects
- Add type guard helpers: isTask(), isProject(), isEpic(), isRule(), getObjectType()
- Update all call sites in handlers and tool files to use new method names
- Remove unused project-specific CRUD methods (createProject, updateProject, getProject, listProjects, deleteProject)
- Remove unused ProjectData interface
- Add comprehensive JSDoc comments to all renamed methods
- Net reduction of 231 lines (228 insertions, 459 deletions)

All database operations now use consistent object-oriented naming that accurately reflects their generic nature, improving code clarity and maintainability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>