### PR TITLE
refactor: standardize create handler response to use parent_id/parent_name

### DIFF
--- a/mcp/src/tools/create-handler.ts
+++ b/mcp/src/tools/create-handler.ts
@@ -160,11 +160,8 @@ export async function handleCreate(
     type: typeDisplay.toLowerCase(),
     title: title,
     description: description,
-    // Use appropriate field names based on entity type
-    ...(config.typeName === "Project"
-      ? { parent_id: projectId, parent_name: projectInfo }
-      : { project_id: projectId, project_name: projectInfo }
-    ),
+    parent_id: projectId,
+    parent_name: projectInfo,
     template_id: templateId,
     stage: taskData.stage || 'draft',
     // Add all dynamic properties


### PR DESCRIPTION
Remove conditional field naming logic that output different fields based on
entity type. All create tool responses now consistently use parent_id and
parent_name fields instead of project_id/project_name for non-Project entities.

This eliminates technical debt and creates a clean, predictable API contract
across all entity types (Task, Epic, Rule, Project).

Related: task-895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>