### PR TITLE
feat: add consistent validateTemplateId validation to all update handlers

### DIFF
--- a/mcp/src/tools/epic-tools.ts
+++ b/mcp/src/tools/epic-tools.ts
@@ -105,9 +105,9 @@ export class EpicTools {
         typeName: "Epic",
         idField: "epic_id",
         loadSchema: this.loadDynamicSchemaProperties,
-        validateTemplateId: true,
+        validateTemplateId: true, // Prevent cross-type updates (e.g., using epic_id on a task)
         validateParent: async (parentId: number, dbService: DatabaseService) => {
-          // Validate that parent is a project (template_id=2)
+          // Validate that parent is a project (template_id=2) - epics must belong to projects
           const parentProject = await dbService.getObject(parentId);
           if (!parentProject || parentProject.template_id !== 2) {
             throw new Error("Error: Epics must have a project as parent (template_id=2).");

--- a/mcp/src/tools/project-tools.ts
+++ b/mcp/src/tools/project-tools.ts
@@ -124,6 +124,7 @@ export class ProjectTools {
         typeName: "Project",
         idField: "project_id",
         loadSchema: this.loadProjectSchemaProperties,
+        validateTemplateId: true, // Prevent cross-type updates (e.g., using project_id on a task)
       },
       toolArgs,
       this.sharedDbService,

--- a/mcp/src/tools/rule-tools.ts
+++ b/mcp/src/tools/rule-tools.ts
@@ -98,7 +98,7 @@ export class RuleTools {
         typeName: "Rule",
         idField: "rule_id",
         loadSchema: this.loadRuleSchemaProperties,
-        validateTemplateId: true,
+        validateTemplateId: true, // Prevent cross-type updates (e.g., using rule_id on a project)
       },
       toolArgs,
       this.sharedDbService,

--- a/mcp/src/tools/task-tools.ts
+++ b/mcp/src/tools/task-tools.ts
@@ -98,6 +98,7 @@ export class TaskTools {
         typeName: "Task",
         idField: "task_id",
         loadSchema: this.loadDynamicSchemaProperties,
+        validateTemplateId: true, // Prevent cross-type updates (e.g., using task_id on an epic)
         postUpdate: async (taskId: number, updatedTask: any, dbService: DatabaseService, clientId: string) => {
           // Check if task is completed based on checkboxes in Items section
           if (updatedTask.Items && this.isTaskCompleted(updatedTask.Items)) {

--- a/mcp/src/tools/update-handler.ts
+++ b/mcp/src/tools/update-handler.ts
@@ -5,13 +5,27 @@ import DatabaseService from "../database.js";
 
 /**
  * Configuration for the generic update handler
+ *
+ * Guidelines for validation flags:
+ *
+ * - validateTemplateId: Should be TRUE for all entity types to prevent cross-type updates.
+ *   Example: Prevents accidentally updating a Task when using an epic_id parameter.
+ *   This ensures type safety and prevents data corruption from mismatched tool calls.
+ *
+ * - validateParent: Use when parent relationships have specific constraints.
+ *   Example: Epics must have Project parents (template_id=2), not Task or Rule parents.
+ *   Implement custom validation logic to verify parent entity type and constraints.
+ *
+ * - postUpdate: Use for entity-specific post-processing after successful update.
+ *   Example: Auto-transition task to 'review' stage when all checklist items completed.
+ *   Runs after database update completes, receives updated entity for inspection.
  */
 export interface UpdateConfig {
   templateId: number;
   typeName: string; // e.g., "Task", "Project", "Epic", "Rule"
   idField: string; // e.g., "task_id", "project_id", "epic_id", "rule_id"
   loadSchema: () => Promise<SchemaProperties>;
-  validateTemplateId?: boolean; // If true, verify entity template_id matches
+  validateTemplateId?: boolean; // If true, verify entity template_id matches (recommended: true for all types)
   validateParent?: (parentId: number, dbService: DatabaseService) => Promise<void>;
   postUpdate?: (entityId: number, entity: any, dbService: DatabaseService, clientId: string) => Promise<any>;
 }


### PR DESCRIPTION
Add validateTemplateId: true to Task and Project update handlers to match
Epic and Rule implementations. This ensures type safety across all entity
types and prevents accidental cross-type updates (e.g., updating a Task
when using an epic_id parameter).

Enhanced UpdateConfig interface with comprehensive documentation explaining
when to use each validation flag:
- validateTemplateId: Recommended for all entity types to prevent cross-type updates
- validateParent: Use when parent relationships have specific constraints
- postUpdate: Use for entity-specific post-processing logic

Added inline comments to all tool update handlers explaining validation
flag choices, establishing clear patterns for future implementations.

Related: task-896

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>